### PR TITLE
dependency bumps for theme compat and django 6.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,25 +7,43 @@ jobs:
     runs-on: ubuntu-latest
     name: Python ${{ matrix.python-version }} - Django ${{ matrix.django-version }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-        django-version: ["4.2", "5.2", "6.0"]
-        exclude:
-          # django 6.0 requires python >=3.12
+        include:
+          # Django 4.2 — Python 3.9–3.12
           - python-version: "3.9"
-            django-version: "6.0"
+            django-version: "4.2"
           - python-version: "3.10"
-            django-version: "6.0"
+            django-version: "4.2"
           - python-version: "3.11"
-            django-version: "6.0"
-          # Django 5.0+ requires Python 3.10+
-          - python-version: "3.9"
+            django-version: "4.2"
+          - python-version: "3.12"
+            django-version: "4.2"
+          # Django 5.2 — Python 3.10–3.14
+          - python-version: "3.10"
             django-version: "5.2"
-          # Django 4.2+ requires python <3.14
-          - python-version: "3.14"
-            django-version: "4.2"
+          - python-version: "3.11"
+            django-version: "5.2"
+          - python-version: "3.12"
+            django-version: "5.2"
           - python-version: "3.13"
-            django-version: "4.2"
+            django-version: "5.2"
+          - python-version: "3.14"
+            django-version: "5.2"
+          # Django 6.0 — Python 3.12–3.14
+          - python-version: "3.12"
+            django-version: "6.0"
+          - python-version: "3.13"
+            django-version: "6.0"
+          - python-version: "3.14"
+            django-version: "6.0"
+          # Django 6.1 — Python 3.12–3.14
+          - python-version: "3.12"
+            django-version: "6.1"
+          - python-version: "3.13"
+            django-version: "6.1"
+          - python-version: "3.14"
+            django-version: "6.1"
 
     services:
       redis:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ DJ Celery Panel brings Celery monitoring directly into the Django Admin.
 
 ![DJ Celery Panel](https://raw.githubusercontent.com/django-control-room/dj-celery-panel/main/images/django-celery.png)
 
-**Compatible with [dj-control-room](https://github.com/django-control-room/dj-control-room).** Register this panel in the Control Room to manage it from a centralized dashboard.
+**Compatible with [dj-control-room](https://django-control-room.github.io/dj-control-room/).** Register this panel in the Control Room to manage it from a centralized dashboard.
 
 - **Official site:** [djangocontrolroom.com](https://djangocontrolroom.com)
 - **Project repo:** [dj-control-room](https://github.com/django-control-room/dj-control-room)
@@ -115,10 +115,10 @@ For the full walkthrough, settings reference (swappable backends, periodic tasks
 
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License. See the [LICENSE](https://github.com/django-control-room/dj-celery-panel/blob/main/LICENSE) file for details.
 
 ---
 
-## Development Setup
+## Contributing
 
-Want to contribute or set up the project for local development? See [docs/development.md](docs/development.md) for prerequisites, Docker/virtualenv setup, running the example project, and the test suite.
+Want to contribute or set up the project for local development? See [Contributing](https://django-control-room.github.io/dj-celery-panel/contributing/) for prerequisites, Docker/virtualenv setup, running the example project, and the test suite.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,4 @@
-# Development
-
+# Contributing
 Contributing to Django Celery Panel or setting up for local development.
 
 ## Prerequisites

--- a/docs/features.md
+++ b/docs/features.md
@@ -331,4 +331,4 @@ Django Celery Panel is perfect for:
 
 - [Installation Guide](installation.md) - Get started with Django Celery Panel
 - [Configuration](configuration.md) - Customize the panel for your needs
-- [Development](development.md) - Contribute or run tests locally
+- [Contributing](contributing.md) - Contribute or run tests locally

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,10 +87,10 @@ Configuration display includes:
 
 ## Quick Links
 
-- [Features](features.md) - Detailed features with screenshots
-- [Installation](installation.md)
-- [Configuration](configuration.md)
-- [Development](development.md)
+- [Features](https://django-control-room.github.io/dj-celery-panel/features/) - Detailed features with screenshots
+- [Installation](https://django-control-room.github.io/dj-celery-panel/installation/)
+- [Configuration](https://django-control-room.github.io/dj-celery-panel/configuration/)
+- [Contributing](https://django-control-room.github.io/dj-celery-panel/contributing/)
 
 ## Requirements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,10 +87,10 @@ Configuration display includes:
 
 ## Quick Links
 
-- [Features](https://django-control-room.github.io/dj-celery-panel/features/) - Detailed features with screenshots
-- [Installation](https://django-control-room.github.io/dj-celery-panel/installation/)
-- [Configuration](https://django-control-room.github.io/dj-celery-panel/configuration/)
-- [Contributing](https://django-control-room.github.io/dj-celery-panel/contributing/)
+- [Features](features.md) - Detailed features with screenshots
+- [Installation](installation.md)
+- [Configuration](configuration.md)
+- [Contributing](contributing.md)
 
 ## Requirements
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,7 @@ nav:
     - Installation: installation.md
     - Configuration: configuration.md
     - Scopes: scopes.md
-  - Development: development.md
+  - Contributing: contributing.md
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dj-celery-panel"
-version = "0.5.0"
+version = "0.6.0"
 description = "A Django Admin panel for browsing and inspecting Celery tasks and workers"
 readme = "README.md"
 license = {text = "MIT"}
@@ -22,6 +22,7 @@ classifiers = [
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
+    "Framework :: Django :: 6.1",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -36,7 +37,7 @@ classifiers = [
 keywords = ["django", "celery", "admin", "panel", "tasks", "django-celery"]
 dependencies = [
     "Django>=4.2",
-    "dj-control-room-base>=1.4.0",
+    "dj-control-room-base>=1.5.0",
 ]
 
 [project.entry-points."dj_control_room.panels"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # core dependencies
 Django>=4.2
-dj-control-room-base>=1.4.0
-dj-control-room>=1.5.0
+dj-control-room-base>=1.5.0
+dj-control-room>=1.7.1
 django-celery-results>=2.4.0
 django-celery-beat>=2.8.1
 celery>=5.4.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated links to hosted documentation and contribution guidance.
  * Renamed the Development section to Contributing across documentation navigation and references.
* **Compatibility**
  * Expanded tested Django and Python version combinations, including Django 6.0 and 6.1.
* **Release Updates**
  * Updated the package version to 0.6.0.
  * Added Django 6.1 to supported version classifiers.
  * Raised minimum supported package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->